### PR TITLE
Tests for Trampoline Functions

### DIFF
--- a/core/python/test/rostest_mtc.py
+++ b/core/python/test/rostest_mtc.py
@@ -11,27 +11,6 @@ from std_msgs.msg import Header
 import rospy
 
 
-class PyGenerator(core.Generator):
-    def __init__(self, name="python generator"):
-        core.Generator.__init__(self, name)
-        self.num = 5
-
-    # def init(self, robot):
-    #     print("INIT")
-    #     core.Generator.init(self, robot)
-
-    def reset(self):
-        print('RESET')
-        #core.Generator.reset(self)
-
-    def canCompute(self):
-        return self.num > 0
-
-    def compute(self):
-        self.num -= 1
-        print("compute called")
-
-
 class Test(unittest.TestCase):
     PLANNING_GROUP = "manipulator"
 
@@ -48,7 +27,7 @@ class Test(unittest.TestCase):
         task.add(stages.CurrentState("current"))
         move = stages.MoveRelative("move", core.JointInterpolationPlanner())
         move.group = self.PLANNING_GROUP
-        move.setDirection({"joint_1" : 0.2, "joint_2" : 0.4})
+        move.setDirection({"joint_1": 0.2, "joint_2": 0.4})
         task.add(move)
 
         task.enableIntrospection()
@@ -63,13 +42,14 @@ class Test(unittest.TestCase):
 
     def test_Merger(self):
         cartesian = core.CartesianPath()
+
         def createDisplacement(group, displacement):
             move = stages.MoveRelative("displace", cartesian)
             move.group = group
-            move.ik_frame = PoseStamped(header = Header(frame_id = "tool0"))
+            move.ik_frame = PoseStamped(header=Header(frame_id="tool0"))
             dir = Vector3Stamped(
-                header = Header(frame_id = "base_link"),
-                vector = Vector3(*displacement)
+                header=Header(frame_id="base_link"),
+                vector=Vector3(*displacement)
             )
             move.setDirection(dir)
             move.restrictDirection(stages.MoveRelative.Direction.FORWARD)
@@ -79,19 +59,13 @@ class Test(unittest.TestCase):
         task.add(stages.CurrentState("current"))
         merger = core.Merger("merger")
         merger.insert(createDisplacement(self.PLANNING_GROUP, [-0.2, 0, 0]))
-        merger.insert(createDisplacement(self.PLANNING_GROUP, [ 0.2, 0, 0]))
+        merger.insert(createDisplacement(self.PLANNING_GROUP, [0.2, 0, 0]))
         task.add(merger)
 
         task.enableIntrospection()
         task.init()
         if task.plan():
             task.publish(task.solutions[0])
-
-    def test_PyGenerator(self):
-        task = core.Task()
-        keep_alive = PyGenerator()
-        task.add(keep_alive)
-        task.plan()
 
 
 if __name__ == '__main__':

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import unittest
+import mock
 import rostest
 from moveit.python_tools import roscpp_init
 from moveit.task_constructor import core, stages
@@ -13,12 +14,15 @@ import copy
 
 
 class TestTrampolines(unittest.TestCase):
-    """ Test the functionality of pybind11 trampoline classes.
+    """ Test the functionality of trampoline classes.
     - Python classes are able to inherit from C++ base classes, which are
       exposed to python through trampoline classes and bindings.
     - Test for overriding of virtual inheritance of member functions
       and correct construction of the classes.
     """
+
+    def setUp(self):
+        roscpp_init("test_mtc")
 
     def check(self, test_class, **kwargs):
         """Test a trampoline class.
@@ -53,21 +57,11 @@ class TestTrampolines(unittest.TestCase):
             if "name" in kwargs:
                 self.assertEqual(test_class.name, kwargs.get("name"))
 
-        # perform checks
+        # actually call the checks
         _checkParameters(test_class)
         _checkBases(test_class)
 
     def test_connecting(self):
-        def checkInTask(test_class):
-            """ Checks correct insertion into the mtc task hierarchy.
-            - The @p test_class should be able to connect two generator stages.
-            """
-            task = core.Task()
-            task.add(stages.CurrentState("current"))
-            task.add(test_class)
-            task.add(stages.CurrentState("current"))
-            task.plan()
-
         class extConnecting(core.Connecting):
             """ Implements a 'Connecting' stage
             """
@@ -76,72 +70,67 @@ class TestTrampolines(unittest.TestCase):
                 core.Connecting.__init__(self, name)
 
             def compute(self, from_state, to_state):
-                print('compute called')
+                pass
 
         kwargs = {'name': 'Connecting'}
-        conn = extConnecting(kwargs.get('name'))
+        connecting = extConnecting(kwargs.get('name'))
 
         # check parameters and base classes
-        self.check(conn, **kwargs)
+        self.check(connecting, **kwargs)
 
-        # check task insertion
-        checkInTask(conn)
+        with mock.patch.object(extConnecting, 'compute') as compute:
+            task = core.Task()
+            task.add(stages.CurrentState("current"))
+            task.add(connecting)
+            task.add(stages.CurrentState("current"))
+            task.plan()
+            task.reset()
+
+            compute.assert_called_once()
 
     def test_generator(self):
-        def checkInTask(test_class):
-            """ Checks correct insertion into the mtc task hierarchy.
-            - The @ p test_class should be able to be inserted as a
-              generator into the task hierarchy.
-            """
-            task = core.Task()
-            task.add(test_class)
-            task.plan()
-
         class extGenerator(core.Generator):
             """ Implements a 'Generator' stage.
             """
 
             def __init__(self, name):
                 core.Generator.__init__(self, name)
-                self.num = 1
+                self.num = self.computeCalls = 3
 
             def reset(self):
-                print('RESET')
+                pass
 
             def canCompute(self):
                 return self.num > 0
 
             def compute(self):
                 self.num -= 1
-                print("compute called")
 
         kwargs = {"name": 'Generator'}
-        gen = extGenerator(kwargs.get('name'))
-        self.check(gen, **kwargs)
+        generator = extGenerator(kwargs.get('name'))
+        self.check(generator, **kwargs)
 
-        # check task insertion
-        checkInTask(gen)
+        with mock.patch.object(extGenerator, 'canCompute', wraps=generator.canCompute) as canCompute, \
+                mock.patch.object(extGenerator, 'compute', wraps=generator.compute) as compute:
+
+            task = core.Task()
+            task.add(generator)
+            task.plan()
+            task.reset()
+
+            canCompute.assert_called()
+
+            # canCompute should be called computeCount * 2 + 1 times:
+            #   - check inside stage itself and it's wrapping container
+            self.assertEqual(
+                canCompute.call_count,
+                generator.computeCalls * 2 + 1)
+
+            compute.assert_called()
+            self.assertEqual(compute.call_count, generator.computeCalls)
 
     @unittest.skip("Monitoring Generator is not yet ready.")
     def test_monitoringGenerator(self):
-        def checkInTask(test_class):
-            """ Checks correct insertion into the mtc task hierarchy
-            - The @ p test_class is tested to be able to ...
-                1. ... be inserted as a monitoring generator stage
-                2. ... execute the setMonitoredStage Method
-            """
-            task = core.Task()
-            task.add(stages.CurrentState('current'))
-
-            # sanity check
-            self.assertEqual(task['current'].name, 'current')
-
-            # add the monitored stage to the monitoring generator
-            test_class.setMonitoredStage(task['current'])
-
-            task.add(test_class)
-            task.plan()
-
         class extMonitoringGenerator(core.MonitoringGenerator):
             """ Implements a 'MonitoringGenerator' stage.
             """
@@ -153,24 +142,27 @@ class TestTrampolines(unittest.TestCase):
                 print('onNewSolution called')
 
         kwargs = {'name': 'MonitoringGenerator'}
-        mgen = extMonitoringGenerator(kwargs.get('name'))
-        self.check(mgen, **kwargs)
+        monitoringGenerator = extMonitoringGenerator(kwargs.get('name'))
+        self.check(monitoringGenerator, **kwargs)
 
-        # check task insertion
-        checkInTask(mgen)
-
-    def test_propagatingEitherWay(self):
-        def checkInTask(test_class):
-            """ Checks correct insertion into the mtc task hierarchy.
-            - The stage @ p test_class should be able to propagate a generator
-              signal into an arbitrary direction.
-            """
+        with mock.patch.object(extMonitoringGenerator, 'onNewSolution', wraps=monitoringGenerator.onNewSolution) as onNewSolution:
 
             task = core.Task()
             task.add(stages.CurrentState('current'))
-            task.add(test_class)
-            task.plan()
 
+            # sanity check
+            self.assertEqual(task['current'].name, 'current')
+
+            # add the monitored stage to the monitoring generator
+            monitoringGenerator.setMonitoredStage(task['current'])
+
+            task.add(monitoringGenerator)
+            task.plan()
+            task.reset()
+
+            onNewSolution.assert_called()
+
+    def test_propagatingEitherWay(self):
         class extPropagatingEitherWay(core.PropagatingEitherWay):
             """ Implements a 'PropagatingEitherWay' stage.
             """
@@ -179,19 +171,43 @@ class TestTrampolines(unittest.TestCase):
                 core.PropagatingEitherWay.__init__(self, name)
 
             def computeForward(self, from_state):
-                print('compute forward')
+                pass
 
             def computeBackward(self, to_state):
-                print('compute backward')
+                pass
 
         kwargs = {'name': 'PropagatingEitherWay'}
-        prop = extPropagatingEitherWay(kwargs.get('name'))
-        self.check(prop, **kwargs)
 
-        # check task insertion
-        checkInTask(prop)
+        propagatingForward = extPropagatingEitherWay(kwargs.get('name'))
+        self.check(propagatingForward, **kwargs)
+
+        propagatingBackward = extPropagatingEitherWay(kwargs.get('name'))
+        self.check(propagatingBackward, **kwargs)
+
+        with mock.patch.object(extPropagatingEitherWay, 'computeForward', wraps=propagatingForward.computeForward) as computeForward, \
+                mock.patch.object(extPropagatingEitherWay, 'computeBackward', wraps=propagatingBackward.computeBackward) as computeBackward:
+
+            # check compute forward
+            task = core.Task()
+            task.add(stages.CurrentState('current'))
+            task.add(propagatingForward)
+            task.plan()
+            task.reset()
+            computeForward.assert_called_once()
+            computeBackward.assert_not_called()
+
+        with mock.patch.object(extPropagatingEitherWay, 'computeForward', wraps=propagatingBackward.computeForward) as computeForward, \
+                mock.patch.object(extPropagatingEitherWay, 'computeBackward', wraps=propagatingBackward.computeBackward) as computeBackward:
+
+            # check compute Backward
+            task = core.Task()
+            task.add(propagatingBackward)
+            task.add(stages.CurrentState('current'))
+            task.plan()
+            task.reset()
+            computeBackward.assert_called_once()
+            computeForward.assert_not_called()
 
 
 if __name__ == '__main__':
-    roscpp_init("test_mtc")
     unittest.main()

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -79,13 +79,13 @@ class TestTrampolines(unittest.TestCase):
                 print('compute called')
 
         kwargs = {'name': 'Connecting'}
-        extConnecting = extConnecting(kwargs.get('name'))
+        conn = extConnecting(kwargs.get('name'))
 
         # check parameters and base classes
-        self.check(extConnecting, **kwargs)
+        self.check(conn, **kwargs)
 
         # check task insertion
-        checkInTask(extConnecting)
+        checkInTask(conn)
 
     def test_generator(self):
         def checkInTask(test_class):
@@ -116,11 +116,11 @@ class TestTrampolines(unittest.TestCase):
                 print("compute called")
 
         kwargs = {"name": 'Generator'}
-        extGenerator = extGenerator(kwargs.get('name'))
-        self.check(extGenerator, **kwargs)
+        gen = extGenerator(kwargs.get('name'))
+        self.check(gen, **kwargs)
 
         # check task insertion
-        checkInTask(extGenerator)
+        checkInTask(gen)
 
     @unittest.skip("Monitoring Generator is not yet ready.")
     def test_monitoringGenerator(self):
@@ -153,11 +153,11 @@ class TestTrampolines(unittest.TestCase):
                 print('onNewSolution called')
 
         kwargs = {'name': 'MonitoringGenerator'}
-        extMonitoringGenerator = extMonitoringGenerator(kwargs.get('name'))
-        self.check(extMonitoringGenerator, **kwargs)
+        mgen = extMonitoringGenerator(kwargs.get('name'))
+        self.check(mgen, **kwargs)
 
         # check task insertion
-        checkInTask(extMonitoringGenerator)
+        checkInTask(mgen)
 
     def test_propagatingEitherWay(self):
         def checkInTask(test_class):
@@ -185,11 +185,11 @@ class TestTrampolines(unittest.TestCase):
                 print('compute backward')
 
         kwargs = {'name': 'PropagatingEitherWay'}
-        extPropagatingEitherWay = extPropagatingEitherWay(kwargs.get('name'))
-        self.check(extPropagatingEitherWay, **kwargs)
+        prop = extPropagatingEitherWay(kwargs.get('name'))
+        self.check(prop, **kwargs)
 
         # check task insertion
-        checkInTask(extPropagatingEitherWay)
+        checkInTask(prop)
 
 
 if __name__ == '__main__':

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -20,13 +20,13 @@ class TestTrampolines(unittest.TestCase):
       and correct construction of the classes.
     """
 
-    def check(self, test_class, **kvargs):
+    def check(self, test_class, **kwargs):
         """Test a trampoline class.
         - Parameter:
             1. test_class: Contains the class to be tested.
-            2. kvargs: Contain the parameters to be tested.
+            2. kwargs: Contain the parameters to be tested.
         - Tests:
-            1. Constructor parameters from kvargs (e.g. "name")
+            1. Constructor parameters from kwargs (e.g. "name")
             2. Inheritance structure
         """
 
@@ -45,13 +45,13 @@ class TestTrampolines(unittest.TestCase):
         def _checkParameters():
             """ Check correct assignment of standard parametes.
             - Tests are only executed if the corresponding key value pair
-              is given in the kvargs.
-            - Possible tests depending on kvargs:
+              is given in the kwargs.
+            - Possible tests depending on kwargs:
                 1. name check
             """
 
-            if "name" in kvargs:
-                self.assertEqual(test_class.name, kvargs.get("name"))
+            if "name" in kwargs:
+                self.assertEqual(test_class.name, kwargs.get("name"))
 
         # get the base classes of the derived instance
         bases = test_class.__class__.__bases__
@@ -81,11 +81,11 @@ class TestTrampolines(unittest.TestCase):
             def compute(self, from_state, to_state):
                 print('compute called')
 
-        kvargs = {'name': 'Connecting'}
-        extConnecting = extConnecting(kvargs.get('name'))
+        kwargs = {'name': 'Connecting'}
+        extConnecting = extConnecting(kwargs.get('name'))
 
         # check parameters and base classes
-        self.check(extConnecting, **kvargs)
+        self.check(extConnecting, **kwargs)
 
         # check task insertion
         checkInTask(extConnecting)
@@ -118,9 +118,9 @@ class TestTrampolines(unittest.TestCase):
                 self.num -= 1
                 print("compute called")
 
-        kvargs = {"name": 'Generator'}
-        extGenerator = extGenerator(kvargs.get('name'))
-        self.check(extGenerator, **kvargs)
+        kwargs = {"name": 'Generator'}
+        extGenerator = extGenerator(kwargs.get('name'))
+        self.check(extGenerator, **kwargs)
 
         # check task insertion
         checkInTask(extGenerator)
@@ -155,9 +155,9 @@ class TestTrampolines(unittest.TestCase):
             def onNewSolution(self, s):
                 print('onNewSolution called')
 
-        kvargs = {'name': 'MonitoringGenerator'}
-        extMonitoringGenerator = extMonitoringGenerator(kvargs.get('name'))
-        self.check(extMonitoringGenerator, **kvargs)
+        kwargs = {'name': 'MonitoringGenerator'}
+        extMonitoringGenerator = extMonitoringGenerator(kwargs.get('name'))
+        self.check(extMonitoringGenerator, **kwargs)
 
         # check task insertion
         checkInTask(extMonitoringGenerator)
@@ -187,9 +187,9 @@ class TestTrampolines(unittest.TestCase):
             def computeBackward(self, to_state):
                 print('compute backward')
 
-        kvargs = {'name': 'PropagatingEitherWay'}
-        extPropagatingEitherWay = extPropagatingEitherWay(kvargs.get('name'))
-        self.check(extPropagatingEitherWay, **kvargs)
+        kwargs = {'name': 'PropagatingEitherWay'}
+        extPropagatingEitherWay = extPropagatingEitherWay(kwargs.get('name'))
+        self.check(extPropagatingEitherWay, **kwargs)
 
         # check task insertion
         checkInTask(extPropagatingEitherWay)

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -16,8 +16,8 @@ class TestTrampolines(unittest.TestCase):
     """ Test the functionality of pybind11 trampoline classes.
     - Python classes are able to inherit from C++ base classes, which are
       exposed to python through trampoline classes and bindings.
-    - Test for overriding of virtual inheritance of memberfunctions
-      and general correct construction of the classes.
+    - Test for overriding of virtual inheritance of member functions
+      and correct construction of the classes.
     """
 
     def check(self, test_class, **kvargs):

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -1,0 +1,200 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+import unittest
+import rostest
+from moveit.python_tools import roscpp_init
+from moveit.task_constructor import core, stages
+from geometry_msgs.msg import PoseStamped, Pose
+from geometry_msgs.msg import Vector3Stamped, Vector3
+from std_msgs.msg import Header
+import rospy
+import copy
+
+
+class TestTrampolines(unittest.TestCase):
+    """ Test the functionality of pybind11 trampoline classes.
+    - Python classes are able to inherit from C++ base classes, which are
+      exposed to python through trampoline classes and bindings.
+    - Test for overriding of virtual inheritance of memberfunctions
+      and general correct construction of the classes.
+    """
+
+    def check(self, test_class, **kvargs):
+        """Test a trampoline class.
+        - Parameter:
+            1. test_class: Contains the class to be tested.
+            2. kvargs: Contain the parameters to be tested.
+        - Tests:
+            1. Constructor parameters from kvargs (e.g. "name")
+            2. Inheritance structure
+        """
+
+        def _checkBases():
+            """ Check inheritance stucture.
+            - Performed tests:
+                1. Number of base classes
+            """
+
+            self.assertEqual(
+                len(bases),
+                1,
+                msg="Class '" + type(test_class).__name__ +
+                "' must only inherit from a single base class.")
+
+        def _checkParameters():
+            """ Check correct assignment of standard parametes.
+            - Tests are only executed if the corresponding key value pair
+              is given in the kvargs.
+            - Possible tests depending on kvargs:
+                1. name check
+            """
+
+            if "name" in kvargs:
+                self.assertEqual(test_class.name, kvargs.get("name"))
+
+        # get the base classes of the derived instance
+        bases = test_class.__class__.__bases__
+
+        # perform checks
+        _checkParameters()
+        _checkBases()
+
+    def test_connecting(self):
+        def checkInTask(test_class):
+            """ Checks correct insertion into the mtc task hierarchy.
+            - The @p test_class should be able to connect two generator stages.
+            """
+            task = core.Task()
+            task.add(stages.CurrentState("current"))
+            task.add(test_class)
+            task.add(stages.CurrentState("current"))
+            task.plan()
+
+        class extConnecting(core.Connecting):
+            """ Implements a 'Connecting' stage
+            """
+
+            def __init__(self, name):
+                core.Connecting.__init__(self, name)
+
+            def compute(self, from_state, to_state):
+                print('compute called')
+
+        kvargs = {'name': 'Connecting'}
+        extConnecting = extConnecting(kvargs.get('name'))
+
+        # check parameters and base classes
+        self.check(extConnecting, **kvargs)
+
+        # check task insertion
+        checkInTask(extConnecting)
+
+    def test_generator(self):
+        def checkInTask(test_class):
+            """ Checks correct insertion into the mtc task hierarchy.
+            - The @ p test_class should be able to be inserted as a
+              generator into the task hierarchy.
+            """
+            task = core.Task()
+            task.add(test_class)
+            task.plan()
+
+        class extGenerator(core.Generator):
+            """ Implements a 'Generator' stage.
+            """
+
+            def __init__(self, name):
+                core.Generator.__init__(self, name)
+                self.num = 1
+
+            def reset(self):
+                print('RESET')
+
+            def canCompute(self):
+                return self.num > 0
+
+            def compute(self):
+                self.num -= 1
+                print("compute called")
+
+        kvargs = {"name": 'Generator'}
+        extGenerator = extGenerator(kvargs.get('name'))
+        self.check(extGenerator, **kvargs)
+
+        # check task insertion
+        checkInTask(extGenerator)
+
+    @unittest.skip("Monitoring Generator is not yet ready.")
+    def test_monitoringGenerator(self):
+        def checkInTask(test_class):
+            """ Checks correct insertion into the mtc task hierarchy
+            - The @ p test_class is tested to be able to ...
+                1. ... be inserted as a monitoring generator stage
+                2. ... execute the setMonitoredStage Method
+            """
+            task = core.Task()
+            task.add(stages.CurrentState('current'))
+
+            # sanity check
+            self.assertEqual(task['current'].name, 'current')
+
+            # add the monitored stage to the monitoring generator
+            test_class.setMonitoredStage(task['current'])
+
+            task.add(test_class)
+            task.plan()
+
+        class extMonitoringGenerator(core.MonitoringGenerator):
+            """ Implements a 'MonitoringGenerator' stage.
+            """
+
+            def __init__(self, name):
+                core.MonitoringGenerator.__init__(self, name)
+
+            def onNewSolution(self, s):
+                print('onNewSolution called')
+
+        kvargs = {'name': 'MonitoringGenerator'}
+        extMonitoringGenerator = extMonitoringGenerator(kvargs.get('name'))
+        self.check(extMonitoringGenerator, **kvargs)
+
+        # check task insertion
+        checkInTask(extMonitoringGenerator)
+
+    def test_propagatingEitherWay(self):
+        def checkInTask(test_class):
+            """ Checks correct insertion into the mtc task hierarchy.
+            - The stage @ p test_class should be able to propagate a generator
+              signal into an arbitrary direction.
+            """
+
+            task = core.Task()
+            task.add(stages.CurrentState('current'))
+            task.add(test_class)
+            task.plan()
+
+        class extPropagatingEitherWay(core.PropagatingEitherWay):
+            """ Implements a 'PropagatingEitherWay' stage.
+            """
+
+            def __init__(self, name):
+                core.PropagatingEitherWay.__init__(self, name)
+
+            def computeForward(self, from_state):
+                print('compute forward')
+
+            def computeBackward(self, to_state):
+                print('compute backward')
+
+        kvargs = {'name': 'PropagatingEitherWay'}
+        extPropagatingEitherWay = extPropagatingEitherWay(kvargs.get('name'))
+        self.check(extPropagatingEitherWay, **kvargs)
+
+        # check task insertion
+        checkInTask(extPropagatingEitherWay)
+
+
+if __name__ == '__main__':
+    roscpp_init("test_mtc")
+    unittest.main()

--- a/core/python/test/rostest_trampoline.py
+++ b/core/python/test/rostest_trampoline.py
@@ -30,19 +30,19 @@ class TestTrampolines(unittest.TestCase):
             2. Inheritance structure
         """
 
-        def _checkBases():
+        def _checkBases(test_class):
             """ Check inheritance stucture.
             - Performed tests:
                 1. Number of base classes
             """
 
             self.assertEqual(
-                len(bases),
+                len(test_class.__class__.__bases__),
                 1,
                 msg="Class '" + type(test_class).__name__ +
                 "' must only inherit from a single base class.")
 
-        def _checkParameters():
+        def _checkParameters(test_class):
             """ Check correct assignment of standard parametes.
             - Tests are only executed if the corresponding key value pair
               is given in the kwargs.
@@ -53,12 +53,9 @@ class TestTrampolines(unittest.TestCase):
             if "name" in kwargs:
                 self.assertEqual(test_class.name, kwargs.get("name"))
 
-        # get the base classes of the derived instance
-        bases = test_class.__class__.__bases__
-
         # perform checks
-        _checkParameters()
-        _checkBases()
+        _checkParameters(test_class)
+        _checkBases(test_class)
 
     def test_connecting(self):
         def checkInTask(test_class):

--- a/core/python/wrapper/src/core.cpp
+++ b/core/python/wrapper/src/core.cpp
@@ -114,6 +114,7 @@ void export_core(pybind11::module& m) {
 
 
 	auto either_way = py::class_<PropagatingEitherWay, Stage, PyPropagatingEitherWay<>>(m, "PropagatingEitherWay")
+		.def(py::init<const std::string&>(), py::arg("name") = std::string("PropagatingEitherWay"))
 		.def("restrictDirection", &PropagatingEitherWay::restrictDirection)
 		.def("computeForward", &PropagatingEitherWay::computeForward)
 		.def("computeBackward", &PropagatingEitherWay::computeBackward)
@@ -127,10 +128,12 @@ void export_core(pybind11::module& m) {
 		.value("BACKWARD", PropagatingEitherWay::BACKWARD);
 
 	py::class_<PropagatingForward, Stage, PyPropagatingEitherWay<PropagatingForward>>(m, "PropagatingForward")
+		.def(py::init<const std::string&>(), py::arg("name") = std::string("PropagatingForward"))
 		.def("computeForward", &PropagatingEitherWay::computeForward)
 		//.def("sendForward", &PropagatingEitherWay::sendForward)
 		;
 	py::class_<PropagatingBackward, Stage, PyPropagatingEitherWay<PropagatingBackward>>(m, "PropagatingBackward")
+		.def(py::init<const std::string&>(), py::arg("name") = std::string("PropagatingBackward"))
 		.def("computeBackward", &PropagatingEitherWay::computeBackward)
 		//.def("sendBackward", &PropagatingEitherWay::sendBackward)
 		;
@@ -151,6 +154,9 @@ void export_core(pybind11::module& m) {
 		.def(py::init<const std::string&>(), py::arg("name") = std::string("connecting"))
 		.def("compute", &Connecting::compute)
 		.def("_compatible", &PubConnecting::compatible)
+		;
+
+	properties::class_<InterfaceState>(m, "InterfaceState")
 		;
 
 	py::class_<ContainerBase, Stage, PyContainerBase<>>(m, "ContainerBase")

--- a/core/python/wrapper/src/core.h
+++ b/core/python/wrapper/src/core.h
@@ -47,8 +47,8 @@ class PyPropagatingEitherWay : public PyStage<T>
 {
 public:
 	using PyStage<T>::PyStage;
-	void computeForward(const InterfaceState& from) override { PYBIND11_OVERRIDE_PURE(void, T, computeForward, from); }
-	void computeBackward(const InterfaceState& to) override { PYBIND11_OVERRIDE_PURE(void, T, computeBackward, to); }
+	void computeForward(const InterfaceState& from_state) override { PYBIND11_OVERRIDE_PURE(void, T, computeForward, from_state); }
+	void computeBackward(const InterfaceState& to_state) override { PYBIND11_OVERRIDE_PURE(void, T, computeBackward, to_state); }
 };
 
 template <class T = Connecting>
@@ -56,8 +56,8 @@ class PyConnecting : public PyStage<T>
 {
 public:
 	using PyStage<T>::PyStage;
-	void compute(const InterfaceState& from, const InterfaceState& to) override {
-		PYBIND11_OVERRIDE_PURE(void, T, compute, from, to);
+	void compute(const InterfaceState& from_state, const InterfaceState& to_state) override {
+		PYBIND11_OVERRIDE_PURE(void, T, compute, from_state, to_state);
 	}
 	bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const override {
 		PYBIND11_OVERRIDE(bool, T, compatible, from_state, to_state);


### PR DESCRIPTION
# Tests for Trampoline Functions
Trampoline functions allow overriding virtual functions of derived `C++` classes from within `Python`. This functionality should be tested to ensure consistent code quality. 

## Contents
- Modify and extend pybind11 wrappers
- Create tests for trampoline classes
- Cleanup `rostest_mtc`