### PR TITLE
Restructure MTC Python Documentation

### DIFF
--- a/core/doc/concepts.rst
+++ b/core/doc/concepts.rst
@@ -3,6 +3,8 @@
 Topic Guides
 ------------
 
+In-depth explanation about the concepts behind the moveit task constructor framework.
+
 .. toctree::
     :maxdepth: 2
 

--- a/core/doc/concepts.rst
+++ b/core/doc/concepts.rst
@@ -1,0 +1,9 @@
+.. _sec-concepts:
+
+Topic Guides
+------------
+
+.. toctree::
+    :maxdepth: 2
+
+    basics

--- a/core/doc/defineproperties.rst
+++ b/core/doc/defineproperties.rst
@@ -1,0 +1,4 @@
+How to define properties
+========================
+
+How to define properties.

--- a/core/doc/howtoguides.rst
+++ b/core/doc/howtoguides.rst
@@ -206,7 +206,7 @@ property to be derived from the monitored stage as shown
 in the example.
 Download the full example code here: :download:`Source <./../../demo/scripts/compute_ik.py>`
 
-.. literalinclude:: ./../../../demo/scripts/compute_ik.py
+.. literalinclude:: ./../../demo/scripts/compute_ik.py
     :language: python
     :lines: 35-45
 

--- a/core/doc/howtoguides.rst
+++ b/core/doc/howtoguides.rst
@@ -1,0 +1,257 @@
+.. _sec-howtoguides:
+
+How-To Guides
+=============
+
+.. _subsec-howto-stage-usage
+
+Stage Usage
+-----------
+
+Short examples on how to use the mtc stages.
+
+.. _subsubsec-howto-alternatives:
+
+Alternatives
+^^^^^^^^^^^^
+
+Using the ``alternatives`` stage, you can plan for multiple
+execution paths.
+Download the full example code here: :download:`Source <./../../demo/scripts/alternatives.py>`
+
+.. literalinclude:: ./../../demo/scripts/alternatives.py
+    :language: python
+    :lines: 22-60
+
+.. _subsubsec-howto-fallbacks:
+
+Fallbacks
+^^^^^^^^^
+
+The ``fallbacks`` stage provides alternative motion planners
+if planning fails with the primary one.
+Download the full example code here: :download:`Source <./../../demo/scripts/fallbacks.py>`
+
+.. literalinclude:: ./../../demo/scripts/fallbacks.py
+    :language: python
+    :lines: 21-38
+
+.. _subsubsec-howto-merger:
+
+Merger
+^^^^^^
+
+Plan and execute sequences in parallel using the ``merger`` stage.
+Download the full example code here: :download:`Source <./../../demo/scripts/merger.py>`
+
+.. literalinclude:: ./../../demo/scripts/merger.py
+    :language: python
+    :lines: 20-36
+
+.. _subsubsec-howto-connect:
+
+Connect
+^^^^^^^
+
+Connect two stages by finding a motion plan between them.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 42-49
+
+.. _subsubsec-howto-fix-collision-objects:
+
+FixCollisionObjects
+^^^^^^^^^^^^^^^^^^^
+
+Check for collisions and resolve them if applicable.
+Download the full example code here: :download:`Source <./../../demo/scripts/fix_collision_objects.py>`
+
+.. literalinclude:: ./../../demo/scripts/fix_collision_objects.py
+    :language: python
+    :lines: 16-23
+
+.. _subsubsec-howto-generate-place-pose:
+
+GeneratePlacePose
+^^^^^^^^^^^^^^^^^^^
+
+Sample feasible poses around an object pose.
+Considers geometry of primitive object type.
+Solutions can be used for inverse
+kinematics calculations.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 24-31, 89-97
+
+.. _subsubsec-howto-generate-grasp-pose:
+
+GenerateGraspPose
+^^^^^^^^^^^^^^^^^
+
+Sample poses around an object pose by providing
+sample density ``angle_delta``.
+Solutions can be used for inverse kinematics
+calculations.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 51-56
+
+.. _subsubsec-howto-generate-pose:
+
+GeneratePose
+^^^^^^^^^^^^
+
+Spawn a pose on new solutions of the monitored stage.
+Download the full example code here: :download:`Source <./../../demo/scripts/generate_pose.py>`
+
+.. literalinclude:: ./../../demo/scripts/generate_pose.py
+    :language: python
+    :lines: 32-45
+
+.. _subsubsec-howto-pick:
+
+Pick
+^^^^
+
+Wraps the task pipeline to execute a pick.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 66-84
+
+.. _subsubsec-howto-place:
+
+Place
+^^^^^
+
+Wraps the task pipeline to execute a pick.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 102-121
+
+.. _subsubsec-howto-simplegrasp:
+
+SimpleGrasp
+^^^^^^^^^^^
+
+Wraps the pose generation and inverse kinematics
+computation for the pick pipeline.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 58-64
+
+.. _subsubsec-howto-simpleungrasp:
+
+SimpleUnGrasp
+^^^^^^^^^^^^^
+
+Wraps the pose generation and inverse kinematics
+computation for the place pipeline.
+The code snipped is part of the :ref:`Pick and Place <subsec-tut-pick-place>` guide.
+Download the full example code here: :download:`Source <./../../demo/scripts/pickplace.py>`
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 99-106
+
+.. _subsubsec-howto-modify-planning-scene:
+
+ModifyPlanningScene
+^^^^^^^^^^^^^^^^^^^
+
+Modify the planning scene.
+Download the full example code here: :download:`Source <./../../demo/scripts/modify_planning_scene.py>`
+
+.. literalinclude:: ./../../demo/scripts/modify_planning_scene.py
+    :language: python
+    :lines: 19-43
+
+.. _subsubsec-howto-fixed-state:
+
+FixedState
+^^^^^^^^^^
+
+Spawn a pre-defined state.
+Download the full example code here: :download:`Source <./../../demo/scripts/fixed_state.py>`
+
+.. literalinclude:: ./../../demo/scripts/fixed_state.py
+    :language: python
+    :lines: 16-25
+
+.. _subsubsec-howto-compute-ik:
+
+ComputeIK
+^^^^^^^^^
+
+Compute the inverse kinematics of the monitored stages'
+solution. Be sure to correctly configure the ``target_pose``
+property to be derived from the monitored stage as shown
+in the example.
+Download the full example code here: :download:`Source <./../../demo/scripts/compute_ik.py>`
+
+.. literalinclude:: ./../../../demo/scripts/compute_ik.py
+    :language: python
+    :lines: 35-45
+
+
+.. _subsubsec-howto-move-to:
+
+MoveTo
+^^^^^^
+
+Use planners to compute a motion plan.
+Download the full example code here: :download:`Source <./../../demo/scripts/cartesian.py>`
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 51-55
+
+
+.. _subsubsec-howto-move-relative:
+
+MoveRelative
+^^^^^^^^^^^^
+
+Move along a relative offset.
+Download the full example code here: :download:`Source <./../../demo/scripts/cartesian.py>`
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 26-31
+
+
+.. _subsec-howto-stage-extension:
+
+Stage Extension
+---------------
+
+.. _subsubsec-howto-move-relative-extension:
+
+MoveRelative
+^^^^^^^^^^^^
+
+You may derive from this stage to extend its functionality.
+``MoveRelative`` itself derives from the propagator stage that
+alters solutions (i.e. computes a motion plan) when they are
+pased through the stage.
+
+.. literalinclude:: ./../../core/python/test/rostest_trampoline.py
+    :language: python
+    :lines: 72-87

--- a/core/doc/howtoguides.rst
+++ b/core/doc/howtoguides.rst
@@ -250,8 +250,35 @@ MoveRelative
 You may derive from this stage to extend its functionality.
 ``MoveRelative`` itself derives from the propagator stage that
 alters solutions (i.e. computes a motion plan) when they are
-pased through the stage.
+passed through the stage.
 
 .. literalinclude:: ./../../core/python/test/rostest_trampoline.py
     :language: python
     :lines: 72-87
+
+.. _subsubsec-howto-generator-extension:
+
+Generator
+^^^^^^^^^
+
+Derive from the ``Generator`` stage to implement your own
+logic in the compute function.
+
+.. literalinclude:: ./../../core/python/test/rostest_trampoline.py
+    :language: python
+    :lines: 23-44
+
+.. _subsubsec-howto-monitoring-generator-extension:
+
+MonitoringGenerator
+^^^^^^^^^^^^^^^^^^^
+
+Derive from the ``MonitoringGenerator`` stage to
+implement your own logic in the compute function.
+Use the monitoring generator instead of the normal
+generator if you need to access solutions of the
+monitored stage (e.g. computation of inverse kinematics).
+
+.. literalinclude:: ./../../core/python/test/rostest_trampoline.py
+    :language: python
+    :lines: 47-69

--- a/core/doc/index.rst
+++ b/core/doc/index.rst
@@ -10,20 +10,31 @@ hypotheses between stages. The framework enables the hierarchical organization o
 basic stages using containers, allowing for sequential as well as parallel compositions.
 For more details, please refer to the associated `ICRA 2019 publication <https://pub.uni-bielefeld.de/download/2918864/2933599/paper.pdf>`_.
 
+
+How the documentation is organized
+----------------------------------
+
+- :ref:`sec-tutorials` guide you
+  through the initial learning process of setting up a task pipeline.
+  Take a look at the :ref:`first steps <subsec-tut-firststeps>` if you
+  are new to the moveit task constructor.
+
+- :ref:`sec-concepts` discuss the architecture and terminology
+  of the moveit task constructor on a fairly high level.
+
+- :ref:`sec-howtoguides` help you to solve
+  specific problems and use cases you might encounter.
+
+- The :ref:`sec-api` provides
+  technical details of the python package. You may
+  look up definitions here and should already
+  have a basic understanding of the key concepts.
+
 .. toctree::
-   :caption: Concepts
-   :maxdepth: 2
+  :maxdepth: 2
+  :hidden:
 
-   basics
-
-API
-^^^
-.. autosummary::
-   :toctree: _autosummary
-   :caption: API
-   :recursive:
-   :template: custom-module-template.rst
-
-   moveit.task_constructor
-   pymoveit_mtc.core
-   pymoveit_mtc.stages
+  tutorials
+  concepts
+  howtoguides
+  reference

--- a/core/doc/reference.rst
+++ b/core/doc/reference.rst
@@ -1,0 +1,14 @@
+.. _sec-api:
+
+API
+---
+
+.. autosummary::
+   :toctree: _autosummary
+   :caption: API
+   :recursive:
+   :template: custom-module-template.rst
+
+   moveit.task_constructor
+   pymoveit_mtc.core
+   pymoveit_mtc.stages

--- a/core/doc/tut_cartesian.rst
+++ b/core/doc/tut_cartesian.rst
@@ -1,0 +1,4 @@
+.. _subsec-tut-cartesian:
+
+Cartesian
+---------

--- a/core/doc/tut_cartesian.rst
+++ b/core/doc/tut_cartesian.rst
@@ -2,3 +2,77 @@
 
 Cartesian
 ---------
+
+The following example demonstrates how to compute a simple point to point motion
+plan using the moveit task constructor. You can take a look at the full
+source code here:
+:download:`Source <./../../demo/scripts/cartesian.py>`
+
+First, lets make sure we specify the planning group and the
+end effector that we want to use.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 14-15
+
+The moveit task constructor provides different planners.
+We will use the ``CartesianPath`` and ``JointInterpolation``
+planners for this example.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 17-19
+
+Lets start by initializing a task and adding the current
+planning scene state and robot state to it.
+This will be the starting state for our motion plan.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 21-24
+
+To compute a relative motion in cartesian space, we can use
+the ``MoveRelative`` stage. Specify the planning group and
+frame relative to which you want to carry out the motion.
+the relative direction can be specified by a ``Vector3Stamped``
+geometry message.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 26-31
+
+Similarly we can move along a different axis.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 33-37
+
+The ``MoveRelative`` stage also offers an interface to
+``Twist`` messages, allowing to specify rotations.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 39-43
+
+Lastly, we can compute linear movements in cartiesian space
+by providing offsets in joint space.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 45-49
+
+If we want to specify goals instead of directions,
+we can use the ``MoveTo`` stage. In the following example
+we use simple joint interpolation to move the robot to
+a named pose. the named pose is defined in the urdf of
+the robot configuration.
+
+.. literalinclude:: ./../../demo/scripts/cartesian.py
+    :language: python
+    :lines: 51-55
+
+Lastly, we invoke the planning mechanism that traverses
+the task hierarchy for us and compute a valid motion plan.
+At this point, when you run this script you are able to
+inspect the solutions of the individual stages in the rviz
+mtc panel.

--- a/core/doc/tut_first-steps.rst
+++ b/core/doc/tut_first-steps.rst
@@ -1,0 +1,6 @@
+.. _subsec-tut-firststeps:
+
+First Steps
+-----------
+
+Here go the first steps.

--- a/core/doc/tut_first-steps.rst
+++ b/core/doc/tut_first-steps.rst
@@ -3,4 +3,20 @@
 First Steps
 -----------
 
-Here go the first steps.
+The MoveIt Task Constructor package contains several basic examples and
+a pick-and-place demo. For all demos you should launch the basic environment:
+
+.. code-block::
+
+    roslaunch moveit_task_constructor_demo demo.launch
+
+Subsequently, you can run the individual demos:
+
+.. code-block::
+
+    rosrun moveit_task_constructor_demo cartesian
+    rosrun moveit_task_constructor_demo modular
+    roslaunch moveit_task_constructor_demo pickplace.launch
+
+To inspect the task hierarchy, be sure that you selected the correct solution topic
+in the reviz moveit task constructor plugin.

--- a/core/doc/tut_pick-and-place.rst
+++ b/core/doc/tut_pick-and-place.rst
@@ -3,5 +3,123 @@
 Pick and Place
 --------------
 
+The following tutorial demonstrates how you can use the moveit
+task constructor to plan and carry out pick and place movements.
+
+First, lets specify the planning group and the
+end effector that you want to use.
+
 .. literalinclude:: ./../../demo/scripts/pickplace.py
     :language: python
+    :lines: 12-14
+
+Next, we add the object that we want to displace to the
+planning scene. To this end, make sure that the planning scene
+not already contains such object.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 16-33
+
+At this point, we are ready to create the task hierarchy.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 39-40
+
+The pipeline planner encapsulates the moveit interface
+to sampling-based geometric motion planners.
+
+.. tip::
+    Planning does not proceed linearly from top to bottom.
+    Rather, it proceeds from the inside out.
+    Connect stages therefore compute a motion plan between
+    two previously calculated subordinate solutions.
+    For a clear visualization, inspect the rviz mtc panel.
+
+Lets connect the current robot state with the solutions of
+the following stages.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 42-49
+
+To pick the object, we first need to know possible end effector
+poses with which we can perform a successful grasp.
+For this, we use a ``GenerateGraspPoseStage``.
+which essentially spawns poses
+with a given ``angle_delta`` in circular fashion around a center
+point.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 51-56
+
+Next, we need to compute the inverse kinematics of the robot arm
+for all previously sampled poses. This way we can
+rule out solutions that are not feasible due to the robot geometry.
+The ``simpleGrasp`` stage combines ik calculation with motion plan
+generation for opening and closing the end effector, as well as attaching
+the object to the robot an disabling collision.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 58-64
+
+Lastly, we can insert all the previous steps into the ``Pick``
+container stage. At this point we might also specify approach and
+lift twists for the robot relative to the object we want to grasp.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 66-81
+
+Since all the previous stages were chained together via their
+constructor arguments, we only need to add the top level ``Pick``
+stage to the task hierarchy.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 83-84
+
+Thats everything we need for picking an object!
+Lets find a motion plan to place the object
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 86-87
+
+Similar to the picking procedure, we define the place task.
+First, start with sampling place poses.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 89-97
+
+Next, wrap the inverse kinematics computation and gripper
+movements.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 99-100
+
+Lastly, add place and retract motions and add the ``Place``
+stage to the task hierarchy.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 102-121
+
+Finally, compute solutions for the task hierarchy and delete
+the planner instances.
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python
+    :lines: 120-128
+
+At this point, you might inspect the task hierarchy in the mtc rviz
+plugin.
+
+.. tip::
+    Use the mtc rviz plugin to graphically inspect the solutions
+    of individual stages in the task hierarchy.

--- a/core/doc/tut_pick-and-place.rst
+++ b/core/doc/tut_pick-and-place.rst
@@ -1,0 +1,7 @@
+.. _subsec-tut-pick-place:
+
+Pick and Place
+--------------
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python

--- a/core/doc/tut_properties.rst
+++ b/core/doc/tut_properties.rst
@@ -1,0 +1,100 @@
+.. _subsec-tut-properties:
+
+Properties
+----------
+
+Properties are named attributes of a stage.
+They can be used to configure the stages behaviour
+and control further substages. Lets take a closer
+look at how to work with properties.
+
+Basic Operations with Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Lets define a property and assign a description, as well as
+a value to it.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 18-25
+
+Notice that a property always has two values: the current value
+and the default value. Before we use the property, we might want to
+check if the current value defined.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 27-28
+
+Now we are ready to safely retrieve the values of the proprty!
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 30-37
+
+The Property Map
+^^^^^^^^^^^^^^^^
+
+Usually a stage comprises multiple properties. A stage
+contains a single PropertyMap that acts as a container for
+all properties associated to that stage.
+
+Lets first create a PropertyMap in isolation and initialize
+some properties using a dict. As you can see, properties can be
+of arbitrary type.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 39-47
+
+Properties can also be initialized using a more pythonic way.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 49-50
+
+There are two ways to retrieve properties back from the property map.
+We might only be interested in in the value of the property:
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 52-53
+
+Or we can obtain a refernece to the whole property object.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 55-56
+
+The PropertyMap class additionally provides an iterator that can be used in loops.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 58-62
+
+Remember that wer initialized our PropertyMap by using a dict. In fact, you
+can also use an existing PropertMap to copy over some properties.
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 64-67
+
+Accessing Properties of a Stage
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can obtain a reference to the the PropertyMap of a stage like so
+
+.. literalinclude:: ./../../demo/scripts/properties.py
+    :language: python
+    :lines: 15-16, 74-75
+
+As mentioned, each stage contains a PropertyMap.
+Stages communicate to each other via their interfaces.
+If you want to forward properties through these interfaces,
+you can use the reference of a stages' property object.
+
+.. literalinclude:: ./../../demo/scripts/compute_ik.py
+    :language: python
+    :lines: 27-28, 35-36, 40-42
+
+Take a look at the :ref:`How-To-Guides <subsubsec-howto-compute-ik>`
+for a full example of this.

--- a/core/doc/tutorials.rst
+++ b/core/doc/tutorials.rst
@@ -1,0 +1,27 @@
+.. _sec-tutorials:
+
+Tutorials
+=========
+
+.. toctree::
+    :caption: Tutorials
+
+.. _subsec-tut-firststeps:
+
+First Steps
+-----------
+
+Here go the first steps.
+
+.. _subsec-tut-cartesian:
+
+Cartesian
+---------
+
+.. _subsec-tut-pick-place
+
+Pick and Place
+--------------
+
+.. literalinclude:: ./../../demo/scripts/pickplace.py
+    :language: python

--- a/core/doc/tutorials.rst
+++ b/core/doc/tutorials.rst
@@ -3,25 +3,13 @@
 Tutorials
 =========
 
+The following tutorials take you step by step through the implementation of fundamental examples
+of the moveit task constructor.
+
 .. toctree::
     :caption: Tutorials
 
-.. _subsec-tut-firststeps:
-
-First Steps
------------
-
-Here go the first steps.
-
-.. _subsec-tut-cartesian:
-
-Cartesian
----------
-
-.. _subsec-tut-pick-place
-
-Pick and Place
---------------
-
-.. literalinclude:: ./../../demo/scripts/pickplace.py
-    :language: python
+    First Steps <tut_first-steps>
+    Cartesian <tut_cartesian>
+    Properties <tut_properties>
+    Pick and Place <tut_pick-and-place>

--- a/core/python/bindings/src/core.cpp
+++ b/core/python/bindings/src/core.cpp
@@ -329,10 +329,9 @@ void export_core(pybind11::module& m) {
 	py::classh<Alternatives, ParallelContainerBase>(m, "Alternatives", R"(
 			Plan for different alternatives in parallel
 			Solution of all children are considered simultaneously.
-
-			.. literalinclude:: ./../../../demo/scripts/alternatives.py
-				:language: python
-				:lines: 22-60
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-alternatives>`
+			for an implementation of a task hierarchy that makes use of the
+			alternatives stage.
 			)")
 	    .def(py::init<const std::string&>(), "name"_a = std::string("Alternatives"));
 
@@ -344,9 +343,9 @@ void export_core(pybind11::module& m) {
 			- Propagator: Forward an incoming ``InterfaceState`` to the next child if the current one ultimately failed on it.
 			- Connect: Only ``Connect`` stages are supported. Pairs of ``InterfaceStates`` are forward to the next child on failure of the current child.
 
-			.. literalinclude:: ./../../../demo/scripts/fallbacks.py
-				:language: python
-				:lines: 21-38
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-fallbacks>`
+			for an implementation of a task hierarchy that makes use of the
+			fallbacks stage.
 			)")
 	    .def(py::init<const std::string&>(), "name"_a = std::string("Fallbacks"));
 
@@ -354,8 +353,9 @@ void export_core(pybind11::module& m) {
 			Plan for different sub tasks in parallel and eventually merge all sub solutions into a single trajectory
 			This requires all children to operate on disjoint ``JointModelGroups``.
 
-			.. literalinclude:: ./../../../demo/scripts/merger.py
-				:language: python
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-merger>`
+			for an implementation of a task hierarchy that makes use of the
+			fallbacks stage.
 			)")
 	    .def(py::init<const std::string&>(), "name"_a = std::string("merger"));
 

--- a/core/python/bindings/src/stages.cpp
+++ b/core/python/bindings/src/stages.cpp
@@ -89,9 +89,9 @@ void export_stages(pybind11::module& m) {
 			- Attach or detach objects to robot links.
 			- Spawn or remove objects.
 
-		.. literalinclude:: ./../../../demo/scripts/modify_planning_scene.py
-			:language: python
-
+		Take a look at the :ref:`How-To-Guides <subsubsec-howto-modify-planning-scene>`
+		for an implementation of a task hierarchy that makes use of the
+		``ModifyPlanningScene`` stage.
 		)")
 		.def(py::init<const std::string&>(), "name"_a = std::string("modify planning scene"))
 		.def("attachObject", &ModifyPlanningScene::attachObject, "Attach an object to a robot link", "name"_a, "link"_a)
@@ -127,9 +127,9 @@ void export_stages(pybind11::module& m) {
 	properties::class_<FixedState, Stage>(m, "FixedState", R"(
 			Spawn a pre-defined PlanningScene state.
 
-			.. literalinclude:: ./../../../demo/scripts/fixed_state.py
-				:language: python
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-fixed-state>`
+			for an implementation of a task hierarchy that makes use of the
+			``FixedState`` stage.
 		)")
 		.def("setState", &FixedState::setState, R"(
 			Use a planning scene pointer to specify which state the Fixed State
@@ -164,9 +164,9 @@ void export_stages(pybind11::module& m) {
 			Properties of the internally received ``InterfaceState`` can be
 			forwarded to the newly generated, externally exposed ``InterfaceState``.
 
-			.. literalinclude:: ./../../../demo/scripts/compute_ik.py
-				:language: python
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-compute-ik>`
+			for an implementation of a task hierarchy that makes use of the
+			``ComputeIK`` stage.
 		)")
 	    .property<std::string>("eef", R"(
 			str: Specify which end effector of the active planning group
@@ -211,12 +211,11 @@ void export_stages(pybind11::module& m) {
 	properties::class_<MoveTo, PropagatingEitherWay, PyMoveTo<>>(m, "MoveTo", R"(
 			Compute a trajectory between the robot state from the
 			interface state of the preceeding stage and a specified
-			goal
+			goal.
 
-			.. literalinclude:: ./../../../demo/scripts/cartesian.py
-				:language: python
-				:lines: 51-55
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-move-to>`
+			for an implementation of a task hierarchy that makes use of the
+			``MoveTo`` stage.
 		)")
 	    .property<std::string>("group", R"(
 			str: Planning group which should be utilized for planning and execution.
@@ -257,18 +256,12 @@ void export_stages(pybind11::module& m) {
 
 	properties::class_<MoveRelative, PropagatingEitherWay, PyMoveRelative<>>(m, "MoveRelative", R"(
 			Perform a Cartesian motion relative to some link.
-
-			.. literalinclude:: ./../../../demo/scripts/cartesian.py
-				:language: python
-				:lines: 26-31
-
-			To implement your own propagtor logic on top of the `moveRelative` class' functionality,
-			you may derive from the stage like so:
-
-			.. literalinclude:: ./../../python/test/rostest_trampoline.py
-				:language: python
-				:lines: 72-87
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-move-relative>`
+			for an implementation of a task hierarchy that makes use of the
+			``MoveRelative`` stage.
+			To implement your own propagtor logic on top of the ``MoveRelative`` class' functionality,
+			you may derive from the stage. Take a look at the corresponding
+			:ref:`How-To-Guide <subsubsec-howto-move-relative>`.
 		)")
 	    .property<std::string>("group", R"(
 			str: Planning group which should be utilized for planning and execution.
@@ -321,12 +314,8 @@ void export_stages(pybind11::module& m) {
 			sub trajectories of individual planning results.
 			If this fails, the sequential planning result is returned.
 
-			The example below contains a snippet from the :ref:`pick pipeline example<pick>`.
-
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-			   :language: python
-			   :lines: 48-60
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-connect>`
+			for a snipped that demonstrates usage of the connect stage.
 		)")
 	    .def(py::init<const std::string&, const Connect::GroupPlannerVector&>(),
 	         "name"_a = std::string("connect"), "planners"_a);
@@ -335,9 +324,9 @@ void export_stages(pybind11::module& m) {
 			Test for collisions and find a correction for applicable objects.
 			Move the objects out of the way along the correction direction.
 
-			.. literalinclude:: ./../../../demo/scripts/fix_collision_objects.py
-				:language: python
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-fix-collision-objects>`
+			for an implementation of a task hierarchy that makes use of the
+			``FixCollisionObjects`` stage.
 		)")
 	    .property<double>("max_penetration", R"(
 			float: Cutoff length up to which collision objects get fixed.
@@ -350,12 +339,8 @@ void export_stages(pybind11::module& m) {
 			``angle_delta`` intervall, GeneratePlacePose samples a fixed amount, which is dependent
 			on the objects shape.
 
-			The example below contains a snippet from the :ref:`pick pipeline example<pick>`.
-
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-				:language: python
-				:lines: 115-122
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-generate-place-pose>`
+			for a snipped that demonstrates usage of the `GeneratePlacePose` stage.
 		)")
 		.property<std::string>("object", R"(
 			str: Name of the object in the planning scene, attached to the robot which should be placed
@@ -373,13 +358,8 @@ void export_stages(pybind11::module& m) {
 			GenerateGraspPose stage derives from monitoring generator and can
 			be used to generate poses for grasping. Set the desired attributes
 			of the grasp using the stages properties.
-
-			The example below contains a snippet from the :ref:`pick pipeline example<pick>`.
-
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-			   :language: python
-			   :lines: 62-68
-
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-generate-grasp-pose>`
+			for a snipped that demonstrates usage of the `GenerateGraspPose` stage.
 		)")
 	    .property<std::string>("object", R"(
 			str: Name of the Object in the planning scene, which should be grasped
@@ -398,9 +378,9 @@ void export_stages(pybind11::module& m) {
 			Monitoring generator stage which can be used to generate a pose, based on solutions provided
 			by the monitored stage.
 
-			.. literalinclude:: ./../../../demo/scripts/generate_pose.py
-				:language: python
-				:lines: 35-48
+			Take a look at the :ref:`How-To-Guides <subsubsec-howto-fix-collision-objects>`
+			for an implementation of a task hierarchy that makes use of the
+			``GeneratePose`` stage.
 		)")
 	    .property<geometry_msgs::PoseStamped>("pose", R"(
 			PoseStamped_: Set the pose, which should be spawned on each new solution of the monitored stage.
@@ -423,13 +403,10 @@ void export_stages(pybind11::module& m) {
 			as the end effector's cartesian pose needs to be provided by an external
 			grasp stage.
 
-			The example below combines pick and place routines in a single pickplace pipeline.
-			Please refer to the demonstration scripts of the moveit task constructor repository
-			for reference.
-
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-				:language: python
-
+			Take a look at the :ref:`Pick and Place Tutorial <subsec-tut-pick-place>` for an in-depth look,
+			as well as the :ref:`How-To Guide <subsubsec-howto-pick>` for a minimal implementation
+			of a task hierarchy that makes use of the
+			``Pick`` stage.
 		)")
 	    .property<std::string>("object", "str: Name of object to pick")
 	    .property<std::string>("eef", "str: The End effector name")
@@ -469,11 +446,10 @@ void export_stages(pybind11::module& m) {
 			as the end effector's Cartesian pose needs to be provided by an external
 			grasp stage.
 
-			For a working example, please consider the :doc:`Pick <pymoveit_mtc.stages.Pick>` stage.
-
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-				:language: python
-				:lines: 102-118
+			Take a look at the :ref:`Pick and Place Tutorial <subsec-tut-pick-place>` for an in-depth look,
+			as well as the :ref:`How-To Guide <subsubsec-howto-place>` for a minimal implementation
+			of a task hierarchy that makes use of the
+			``Place`` stage.
 		)")
 	    .property<std::string>("object", "str: Name of object to pick")
 	    .property<std::string>("eef", "str: The End effector name")
@@ -501,12 +477,11 @@ void export_stages(pybind11::module& m) {
 
 	properties::class_<SimpleGrasp, Stage>(m, "SimpleGrasp", R"(
 			Specialization of SimpleGraspBase to realize grasping.
-			Refer to the :doc:`Pick <pymoveit_mtc.stages.Pick>`
-			stage for a minimum code example:
 
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-				:language: python
-				:lines: 58-64
+			Take a look at the :ref:`Pick and Place Tutorial <subsec-tut-pick-place>` for an in-depth look,
+			as well as the :ref:`How-To Guide <subsubsec-howto-simplegrasp>` for a minimal implementation
+			of a task hierarchy that makes use of the
+			``SimpleGrasp`` stage.
 		)")
 	    .property<std::string>("eef", "str: The end effector of the robot")
 	    .property<std::string>("object", "str: The object to grasp (Must be present in the planning scene)")
@@ -543,15 +518,11 @@ void export_stages(pybind11::module& m) {
 
 	properties::class_<SimpleUnGrasp, Stage>(m, "SimpleUnGrasp", R"(
 			Specialization of SimpleGraspBase to realize ungrasping
-			Refer to the :doc:`Place <pymoveit_mtc.stages.Place>`
-			stage for a minimum code example.
-			Be sure to forward the ``grasp`` and ``pregrasp`` properties
-			through the stage hierarchy so that they are available here again.
 
-			.. literalinclude:: ./../../../demo/scripts/pickplace.py
-				:language: python
-				:lines: 99-100
-
+			Take a look at the :ref:`Pick and Place Tutorial <subsec-tut-pick-place>` for an in-depth look,
+			as well as the :ref:`How-To Guide <subsubsec-howto-simplegrasp>` for a minimal implementation
+			of a task hierarchy that makes use of the
+			``SimpleUnGrasp`` stage.
 		)")
 	    .property<std::string>("eef", "str: The end effector of the robot")
 	    .property<std::string>("object", "str: The object to grasp (Must be present in the planning scene)")

--- a/demo/scripts/properties.py
+++ b/demo/scripts/properties.py
@@ -1,0 +1,78 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from moveit.task_constructor import core, stages
+from geometry_msgs.msg import PoseStamped
+import time
+
+from moveit.python_tools import roscpp_init
+
+roscpp_init("mtc_tutorial")
+
+# Create a task container
+task = core.Task()
+
+# Create a current state to capture the current planning scene state
+currentState = stages.CurrentState("Current State")
+
+# Create a property
+p = core.Property()
+
+# Set a descriptive string to describe the properties function
+p.setDescription("Foo Property")
+
+# Set the current and the default value
+p.setValue("Bar")
+
+# Check if the property is defined
+assert p.defined()
+
+# Retrieve the stored value
+print(p.value())
+
+# Retrieve the default value
+print(p.defaultValue())
+
+# Retrieve the description
+print(p.description())
+
+# Create a property map
+pm = core.PropertyMap()
+props = {"prop1": "test", "prop2": 21, "prop3": PoseStamped(), "prop4": 5.4}
+pm.update(props)
+
+# Add a property to the property map using the pythonic way
+pm["prop5"] = 2
+
+# Return the value of a property
+print(pm["prop5"])
+
+# Return the underlying property object
+p2 = pm.property("prop5")
+
+# Iterate through all the values in the property map
+print("\n")
+for i in pm:
+    print(i, "\t\t", pm[i])
+print("\n")
+
+# A new property map can also be configured using an existing one
+# You can also only use a subset of the properties that should be configured.
+pm2 = core.PropertyMap()
+pm.exposeTo(pm2, ["prop2", "prop4"])
+
+# Lets test that by printing out our properties
+for i in pm2:
+    print(i, "\t\t", pm2[i])
+print("\n")
+
+# Access the property map of the stage
+props = currentState.properties
+
+# Add the stage to the task hierarchy
+task.add(currentState)
+
+if task.plan():
+    task.publish(task.solutions[0])
+
+time.sleep(100)


### PR DESCRIPTION
### Description
Currently, the documentation for the the python interface of the moveit task constructor mixes usage examples with api reference. This makes it hard to find code snippets and generally clutters up the documentation.  Additionally, it would be great to have tutorials, guiding the reader through the first steps of using the moveit task constructor.

This PR aims to split up the documentation and structure it in the following way:
- Api Reference
- Tutorials
- How-To Guides
- Topic Guides

I would really appreciate some feedback and would love to incorporate that and any additional ideas in the tutorial!